### PR TITLE
changes to us new xml format for hg scm (v1.5+)

### DIFF
--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -34,6 +34,9 @@ GIT_URL = './scm/userRemoteConfigs/hudson.plugins.git.UserRemoteConfig/url'
 HG_URL = './scm/source'
 GIT_BRANCH = './scm/branches/hudson.plugins.git.BranchSpec/name'
 HG_BRANCH = './scm/branch'
+# since hg plugin 1.5 revison is used to save branch in xml
+HG_REVISION_TYPE = './scm/revisionType'
+HG_REVISION = './scm/revision'
 DEFAULT_HG_BRANCH_NAME = 'default'
 
 log = logging.getLogger(__name__)
@@ -84,7 +87,13 @@ class Job(JenkinsBase, MutableJenkinsThing):
     # default), Mercurial plugin doesn't store default branch name in config XML
     # file of the job. Create XML node corresponding to default branch
     def _get_hg_branch(self, element_tree):
-        branches = element_tree.findall(HG_BRANCH)
+        revisionType = element_tree.findall(HG_REVISION_TYPE)
+
+        if revisionType:
+            branches = element_tree.findall(HG_REVISION)
+        else:
+            branches = element_tree.findall(HG_BRANCH)
+
         if not branches:
             hg_default_branch = ET.Element('branch')
             hg_default_branch.text = DEFAULT_HG_BRANCH_NAME

--- a/jenkinsapi_tests/unittests/test_job_scm_hg.py
+++ b/jenkinsapi_tests/unittests/test_job_scm_hg.py
@@ -92,6 +92,25 @@ class TestHgJob(unittest.TestCase):
         '''
         return config_node
 
+    def configtree_with_revision(self):
+        config_node = '''
+        <project>
+        <scm class="hudson.plugins.mercurial.MercurialSCM" plugin="mercurial@1.50">
+        <source>http://cm5/hg/sandbox/v01.0/int</source>
+        <modules></modules>
+        <revisionType>BRANCH</revisionType>
+        <revision>testme</revision>
+        <clean>false</clean>
+        <browser class="hudson.plugins.mercurial.browser.HgWeb">
+        <url>http://cm5/hg/sandbox/v01.0/int/</url>
+        </browser>
+        </scm>
+        <disableChangeLog>false</disableChangeLog>
+        </scm>
+        </project>
+        '''
+        return config_node
+
     @mock.patch.object(Job,'get_config',configtree_with_branch)
     def test_hg_attributes(self):
         expected_url = ['http://cm5/hg/sandbox/v01.0/int']
@@ -102,6 +121,13 @@ class TestHgJob(unittest.TestCase):
     @mock.patch.object(Job,'get_config',configtree_with_default_branch)
     def test_hg_attributes_default_branch(self):
         self.assertEquals(self.j.get_scm_branch(),['default'])
+
+    @mock.patch.object(Job,'get_config',configtree_with_revision)
+    def test_hg_attributes(self):
+        expected_url = ['http://cm5/hg/sandbox/v01.0/int']
+        self.assertEquals(self.j.get_scm_type(),'hg')
+        self.assertEquals(self.j.get_scm_url(),expected_url)
+        self.assertEquals(self.j.get_scm_branch(),['testme'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The version 1.5 of hg plugin changed how to save the branch info. see changed test for new format.

