### PR TITLE
Add get_build_url functionality with test case (#318)

### DIFF
--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -310,6 +310,12 @@ class Build(JenkinsBase):
         url_tpl = r"%stestReport/%s"
         return url_tpl % (self._data["url"], config.JENKINS_API)
 
+    def get_build_url(self):
+        """
+        Return build url for job.
+        """
+        return self._data["url"]
+
     def get_resultset(self):
         """
         Obtain detailed results for this build.

--- a/jenkinsapi_tests/unittests/test_build.py
+++ b/jenkinsapi_tests/unittests/test_build.py
@@ -81,6 +81,10 @@ class test_build(unittest.TestCase):
                             'userId': None,
                             'userName': 'anonymous'}])
 
+    def test_get_build_url(self):
+        self.assertEquals(self.b.get_build_url(),
+                          'http://localhost:8080/job/foo/1/')
+
     @mock.patch.object(Build, 'get_data')
     def test_build_depth(self, get_data_mock):
         build = Build('http://halob:8080/job/foo/98', 98, self.j, depth=0)
@@ -94,6 +98,7 @@ class test_build(unittest.TestCase):
     # def test_downstream(self):
     #     expected = ['SingleJob','MultipleJobs']
     #     self.assertEquals(self.b.get_downstream_job_names(), expected)
+
 
 def main():
     unittest.main(verbosity=2)


### PR DESCRIPTION
As mention in issue #318 this feature will enable to get build_url for a particular job.