### PR TITLE
fix invoke(skip_if_running=True) triggering a build even when a build is already running

### DIFF
--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -185,8 +185,7 @@ class Job(JenkinsBase, MutableJenkinsThing):
 
                 elif self.is_running():
                     if skip_if_running:
-                        log.warn(
-                            "Will not request new build because %s is already running", self.name)
+                        raise WillNotBuild('%s is already running' % repr(self))
                     else:
                         log.warn(
                             "Will re-schedule %s even though it is already running", self.name)


### PR DESCRIPTION
When passing `skip_if_running=True` to `Job.invoke()` it prints a warning message (*Will not request new build because JOB_NAME is already running*) but then still triggers a build.