### PR TITLE
Allowing using standalone file parameter with buildWithParameters

### DIFF
--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -134,8 +134,8 @@ class Job(JenkinsBase, MutableJenkinsThing):
             self._element_tree = ET.fromstring(self._config)
         return self._element_tree
 
-    def get_build_triggerurl(self, files):
-        if (files and self.has_params()) or (not files and not self.has_params()):
+    def get_build_triggerurl(self, files, build_params=None):
+        if (files and build_params) or (not self.has_params()):
             # If job has file parameters and non-file parameters - it must be triggered
             # using "/build", not by "/buildWithParameters"
             # "/buildWithParameters" will ignore non-file parameters
@@ -189,7 +189,7 @@ class Job(JenkinsBase, MutableJenkinsThing):
         build_params = build_params and dict(
             build_params.items()) or {}  # Via POSTed JSON
 
-        url = self.get_build_triggerurl(files)
+        url = self.get_build_triggerurl(files, build_params)
         if cause:
             build_params['cause'] = cause
 

--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -135,8 +135,8 @@ class Job(JenkinsBase, MutableJenkinsThing):
         return self._element_tree
 
     def get_build_triggerurl(self, files):
-        if files or (not self.has_params()):
-            # If job has file parameters - it must be triggered
+        if (files and self.has_params()) or (not files and not self.has_params()):
+            # If job has file parameters and non-file parameters - it must be triggered
             # using "/build", not by "/buildWithParameters"
             # "/buildWithParameters" will ignore non-file parameters
             return "%s/build" % self.baseurl

--- a/jenkinsapi_tests/systests/test_parameterized_builds.py
+++ b/jenkinsapi_tests/systests/test_parameterized_builds.py
@@ -27,19 +27,18 @@ class TestParameterizedBuilds(BaseSystemTest):
         job_name = 'create1_%s' % random_string()
         job = self.jenkins.create_job(job_name, JOB_WITH_FILE)
 
-        with self.assertRaises(ValueError) as ve:
-            item = job.invoke(block=True, files={'file.txt': param_file})
+        job.invoke(block=True, files={'file.txt': param_file})
 
-        # Following test is disabled because file parameters do not work
-        #
-        # build = job.get_last_build()
-        # while build.is_running():
-        #     time.sleep(0.25)
+        # Following test is enabled because standalone file parameters work
 
-        # artifacts = build.get_artifact_dict()
-        # self.assertIsInstance(artifacts, dict)
-        # art_file = artifacts['file.txt']
-        # self.assertTrue(art_file.get_data().strip(), file_data)
+        build = job.get_last_build()
+        while build.is_running():
+            time.sleep(0.25)
+
+        artifacts = build.get_artifact_dict()
+        self.assertIsInstance(artifacts, dict)
+        art_file = artifacts['file.txt']
+        self.assertTrue(art_file.get_data().strip(), file_data)
 
     def test_invoke_job_parameterized(self):
         param_B = random_string()


### PR DESCRIPTION
when no other non-file parameters are passed

Currently, the latest version of the library doesn't work with file parameters at all. Period. However, there is a way to do it - just use only file parameters with `buildWithParameters`. In my case, I need to pass a complex parameter structure, and it was easy to put everything into a json file and pass it to Jenkins for further parsing/analysis. 