### PR TITLE
Adds support for requests using file and string parameters

### DIFF
--- a/jenkinsapi/__init__.py
+++ b/jenkinsapi/__init__.py
@@ -66,7 +66,11 @@ __docformat__ = "epytext"
 
 # In case of jenkinsapi is not installed in 'develop' mode
 if not sys.argv[0].endswith('nosetests'):
-    __version__ = pkg_resources.working_set.by_key['jenkinsapi'].version
+    try:
+        __version__ = pkg_resources.working_set.by_key['jenkinsapi'].version
+    except KeyError:
+        # Working directly on repo
+        __version__ = 'dev'
 else:
     # Return bogus version
     __version__ = '99.99.99'

--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -219,10 +219,11 @@ class Job(JenkinsBase, MutableJenkinsThing):
         redirect_url = response.headers['location']
 
         if not redirect_url.startswith("%s/queue/item" % self.jenkins.baseurl):
+            # Queue ID is currently not returned when uploading files.
+            # Guess it with next build number.
             if files:
-                raise ValueError('Builds with file parameters are not '
-                                 'supported by this jenkinsapi version. '
-                                 'Please use previous version.')
+                redirect_url = "%s/queue/item/%d/" % \
+                    (self.jenkins.baseurl, self.get_next_build_number() - 1)
             else:
                 raise ValueError("Not a Queue URL: %s" % redirect_url)
 


### PR DESCRIPTION
The purpose of this pull request is to allow uploading a file along with string parameters to a job, which currently raises an exception.

The queue ID is not returned by Jenkins in the "location" header in this case (https://issues.jenkins-ci.org/browse/JENKINS-12827). 

If this issue occurs, then we try to guess it based on the next build number.