### PR TITLE
Issue361

### DIFF
--- a/jenkinsapi/command_line/jenkins_invoke.py
+++ b/jenkinsapi/command_line/jenkins_invoke.py
@@ -44,7 +44,7 @@ class JenkinsInvoke(object):
         try:
             assert len(args) > 0, "Need to specify at least one job name"
         except AssertionError as err:
-            log.critical(err[0])
+            log.critical(err.message)
             parser.print_help()
             sys.exit(1)
         invoker = cls(options, args)

--- a/jenkinsapi/command_line/jenkinsapi_version.py
+++ b/jenkinsapi/command_line/jenkinsapi_version.py
@@ -1,3 +1,5 @@
+""" jenkinsapi.command_line.jenkinsapi_version
+"""
 from jenkinsapi import __version__ as version
 import sys
 

--- a/jenkinsapi_tests/systests/test_restart.py
+++ b/jenkinsapi_tests/systests/test_restart.py
@@ -46,7 +46,7 @@ class TestRestart(BaseSystemTest):
             self.fail("msg")
 
     def test_safe_restart(self):
-        self.jenkins. poll()  # jenkins should be alive
+        self.jenkins.poll()  # jenkins should be alive
         self.jenkins.safe_restart()
         with self.assertRaises(HTTPError):
             # this is a 503: jenkins is still restarting

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,30 @@
+#
+# jenkinsapi tox.ini
+#
+#   This file helps for developers to simulate locally
+#   what travis will execute when testing merges. See
+#   http://tox.readthedocs.org for configuration info
+#
+#   Usage:
+#     $ pip install tox
+#     $ tox -e py27 # lint/test for python2.7 OR,
+#     $ tox -e py34 # lint/tests for python3.4 OR,
+#     $ tox         # lint/tests for both
+#
+[tox]
+envlist = py26,py27,py34
+
+[testenv]
+deps=
+  nose
+  mock
+  coverage
+  pep8
+  astroid<1.3.0
+  pylint<1.4
+usedevelop=
+  True
+commands=
+  pylint --rcfile=pylintrc jenkinsapi --disable R0912
+  pep8 --ignore=E501 jenkinsapi
+  python setup.py test


### PR DESCRIPTION
Fix for https://github.com/salimfadhley/jenkinsapi/issues/361  

This branch adds a tox configuration that makes it easier to test/lint locally in the same way that travis does.  I could have benefited a lot from this before submitting my first pull request to this project and I expect it will help other outside contributors get started more easily.  I'm not really familiar with travis+github configuration, but it's possible you may just want to setup travis itself to use the tox commands too (this would help avoid any divergence).