### PR TITLE
Update using_jenkinsapi.rst

### DIFF
--- a/doc/source/using_jenkinsapi.rst
+++ b/doc/source/using_jenkinsapi.rst
@@ -31,8 +31,7 @@ Example 2: Get details of jobs running on Jenkins server
     def get_job_details():
         # Refer Example #1 for definition of function 'get_server_instance'
         server = get_server_instance()
-        for j in server.get_jobs():
-            job_instance = server.get_job(j[0])
+        for job_name, job_instance in server.get_jobs():
             print 'Job Name:%s' %(job_instance.name)
             print 'Job Description:%s' %(job_instance.get_description())
             print 'Is Job running:%s' %(job_instance.is_running())


### PR DESCRIPTION
`server.get_jobs()` is already passing back a tuple of (job_name, job_instance), so there is no need to cal get_job() again.