### PR TITLE
Update jenkins.py - create_node with launcher parameter

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -308,7 +308,8 @@ class Jenkins(JenkinsBase):
 
     def create_node(self, name, num_executors=2, node_description=None,
                     remote_fs='/var/lib/jenkins',
-                    labels=None, exclusive=False):
+                    labels=None, exclusive=False, 
+                    launcher='hudson.slaves.JNLPLauncher'):
         """
         Create a new slave node by name.
 
@@ -318,6 +319,7 @@ class Jenkins(JenkinsBase):
         :param remote_fs: jenkins path, str
         :param labels: labels to associate with slave, str
         :param exclusive: tied to specific job, boolean
+        :param launcher: define the launcher, str
         :return: node obj
         """
         NODE_TYPE = 'hudson.slaves.DumbSlave$DescriptorImpl'
@@ -344,7 +346,7 @@ class Jenkins(JenkinsBase):
                     'stapler-class-bag': 'true'
                 },
                 'launcher': {
-                    'stapler-class': 'hudson.slaves.JNLPLauncher'
+                    'stapler-class': launcher
                 }
             })
         }

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -308,7 +308,7 @@ class Jenkins(JenkinsBase):
 
     def create_node(self, name, num_executors=2, node_description=None,
                     remote_fs='/var/lib/jenkins',
-                    labels=None, exclusive=False, 
+                    labels=None, exclusive=False,
                     launcher='hudson.slaves.JNLPLauncher'):
         """
         Create a new slave node by name.


### PR DESCRIPTION
Including option to create a node setting up which launcher should be used.
The hard-coded one is set to default, so nothing to worry about backwards compatibility.