### PR TITLE
KrbRequester.get_request_dict missing **kwargs

### DIFF
--- a/jenkinsapi/utils/krb_requester.py
+++ b/jenkinsapi/utils/krb_requester.py
@@ -29,7 +29,7 @@ class KrbRequester(Requester):
         self.mutual_auth = mutual_auth
 
     def get_request_dict(
-            self, params=None, data=None, files=None, headers=None):
+            self, params=None, data=None, files=None, headers=None, **kwargs):
         req_dict = super(KrbRequester, self).get_request_dict(params=params, data=data, files=files,
                                                               headers=headers)
         if self.mutual_auth:


### PR DESCRIPTION
The standard implementation of `Requester` passes an `allow_redirects` boolean parameter. There's no hook in `KrbRequester` for this parameter, but it seems both unnecessary and unadjustable. Assuming nothing changes in the execution, a simple `**kwargs` permits usage of KrbRequester. This is necessary for us to use the python jenkinsapi libs.