### PR TITLE
FIX: allow jenkinsapi to be used without installation

### DIFF
--- a/jenkinsapi/__init__.py
+++ b/jenkinsapi/__init__.py
@@ -46,7 +46,6 @@ Current code lives on github: https://github.com/salimfadhley/jenkinsapi
 
 """
 import sys
-import pkg_resources
 from jenkinsapi import (
     # Modules
     command_line,
@@ -65,8 +64,11 @@ __all__ = [
 __docformat__ = "epytext"
 
 # In case of jenkinsapi is not installed in 'develop' mode
-if not sys.argv[0].endswith('nosetests'):
-    __version__ = pkg_resources.working_set.by_key['jenkinsapi'].version
-else:
-    # Return bogus version
-    __version__ = '99.99.99'
+__version__ = '99.99.99'
+try:
+  import pkg_resources
+  __version__ = pkg_resources.working_set.by_key['jenkinsapi'].version
+except ImportError:
+  pass
+except KeyError:
+  pass

--- a/jenkinsapi/__init__.py
+++ b/jenkinsapi/__init__.py
@@ -66,9 +66,9 @@ __docformat__ = "epytext"
 # In case of jenkinsapi is not installed in 'develop' mode
 __version__ = '99.99.99'
 try:
-  import pkg_resources
-  __version__ = pkg_resources.working_set.by_key['jenkinsapi'].version
+    import pkg_resources
+    __version__ = pkg_resources.working_set.by_key['jenkinsapi'].version
 except ImportError:
-  pass
+    pass
 except KeyError:
-  pass
+    pass


### PR DESCRIPTION
Dear all, let me request simple change in jenkinsapi/__init__.py file to
allow developers and users to work with jenkinsapi without necessity of installing.

Current (master as of 2015-09-08 or last stable release) does very focused check whether jenkinsapi is used as part of unit testing (nosetests) which is typically not working in deployments where you checkout the code and adjust PYTHONPATH.

My suggestion here is to use bogus version when pkg_resources query fails.
