### PR TITLE
Add ssl_verify flag to the Jenkins class

### DIFF
--- a/jenkinsapi/api.py
+++ b/jenkinsapi/api.py
@@ -22,54 +22,61 @@ from jenkinsapi.custom_exceptions import ArtifactsMissing, TimeOut, BadURL
 log = logging.getLogger(__name__)
 
 
-def get_latest_test_results(jenkinsurl, jobname, username=None, password=None):
+def get_latest_test_results(jenkinsurl, jobname, username=None, password=None,
+                            ssl_verify=True):
     """
     A convenience function to fetch down the very latest test results
     from a jenkins job.
     """
     latestbuild = get_latest_build(jenkinsurl, jobname, username=username,
-                                   password=password)
+                                   password=password, ssl_verify=ssl_verify)
     res = latestbuild.get_resultset()
     return res
 
 
-def get_latest_build(jenkinsurl, jobname, username=None, password=None):
+def get_latest_build(jenkinsurl, jobname, username=None, password=None,
+                     ssl_verify=True):
     """
     A convenience function to fetch down the very latest test results
     from a jenkins job.
     """
-    jenkinsci = Jenkins(jenkinsurl, username=username, password=password)
+    jenkinsci = Jenkins(jenkinsurl, username=username, password=password,
+                        ssl_verify=ssl_verify)
     job = jenkinsci[jobname]
     return job.get_last_build()
 
 
 def get_latest_complete_build(jenkinsurl, jobname,
-                              username=None, password=None):
+                              username=None, password=None, ssl_verify=True):
     """
     A convenience function to fetch down the very latest test results
     from a jenkins job.
     """
-    jenkinsci = Jenkins(jenkinsurl, username=username, password=password)
+    jenkinsci = Jenkins(jenkinsurl, username=username, password=password,
+                        ssl_verify=ssl_verify)
     job = jenkinsci[jobname]
     return job.get_last_completed_build()
 
 
-def get_build(jenkinsurl, jobname, build_no, username=None, password=None):
+def get_build(jenkinsurl, jobname, build_no, username=None, password=None,
+              ssl_verify=True):
     """
     A convenience function to fetch down the test results
     from a jenkins job by build number.
     """
-    jenkinsci = Jenkins(jenkinsurl, username=username, password=password)
+    jenkinsci = Jenkins(jenkinsurl, username=username, password=password,
+                        ssl_verify=ssl_verify)
     job = jenkinsci[jobname]
     return job.get_build(build_no)
 
 
 def get_artifacts(jenkinsurl, jobid=None, build_no=None,
-                  username=None, password=None):
+                  username=None, password=None, ssl_verify=True):
     """
     Find all the artifacts for the latest build of a job.
     """
-    jenkinsci = Jenkins(jenkinsurl, username=username, password=password)
+    jenkinsci = Jenkins(jenkinsurl, username=username, password=password,
+                        ssl_verify=ssl_verify)
     job = jenkinsci[jobid]
     if build_no:
         build = job.get_build(build_no)
@@ -82,7 +89,7 @@ def get_artifacts(jenkinsurl, jobid=None, build_no=None,
 
 
 def search_artifacts(jenkinsurl, jobid, artifact_ids=None,
-                     username=None, password=None):
+                     username=None, password=None, ssl_verify=True):
     """
     Search the entire history of a jenkins job for a list of artifact names.
     If same_build is true then ensure that all artifacts come from the
@@ -91,7 +98,8 @@ def search_artifacts(jenkinsurl, jobid, artifact_ids=None,
     if len(artifact_ids) == 0 or artifact_ids is None:
         return []
 
-    jenkinsci = Jenkins(jenkinsurl, username=username, password=password)
+    jenkinsci = Jenkins(jenkinsurl, username=username, password=password,
+                        ssl_verify=ssl_verify)
     job = jenkinsci[jobid]
     build_ids = job.get_build_ids()
     for build_id in build_ids:
@@ -107,14 +115,16 @@ def search_artifacts(jenkinsurl, jobid, artifact_ids=None,
 
 
 def grab_artifact(jenkinsurl, jobid, artifactid, targetdir,
-                  username=None, password=None, strict_validation=False):
+                  username=None, password=None,
+                  strict_validation=False, ssl_verify=True):
     """
     Convenience method to find the latest good version of an artifact and
     save it to a target directory.
     Directory is made automatically if not exists.
     """
     artifacts = get_artifacts(jenkinsurl, jobid,
-                              username=username, password=password)
+                              username=username, password=password,
+                              ssl_verify=ssl_verify)
     artifact = artifacts[artifactid]
     if not os.path.exists(targetdir):
         os.makedirs(targetdir)
@@ -122,7 +132,8 @@ def grab_artifact(jenkinsurl, jobid, artifactid, targetdir,
 
 
 def block_until_complete(jenkinsurl, jobs, maxwait=12000, interval=30,
-                         raise_on_timeout=True, username=None, password=None):
+                         raise_on_timeout=True, username=None, password=None,
+                         ssl_verify=True):
     """
     Wait until all of the jobs in the list are complete.
     """
@@ -130,7 +141,8 @@ def block_until_complete(jenkinsurl, jobs, maxwait=12000, interval=30,
     assert maxwait > interval
     assert interval > 0
 
-    obj_jenkins = Jenkins(jenkinsurl, username=username, password=password)
+    obj_jenkins = Jenkins(jenkinsurl, username=username, password=password,
+                          ssl_verify=ssl_verify)
     obj_jobs = [obj_jenkins[jid] for jid in jobs]
     for time_left in range(maxwait, 0, -interval):
         still_running = [j for j in obj_jobs if j.is_queued_or_running()]
@@ -146,7 +158,7 @@ def block_until_complete(jenkinsurl, jobs, maxwait=12000, interval=30,
                       % str_still_running)
 
 
-def get_view_from_url(url, username=None, password=None):
+def get_view_from_url(url, username=None, password=None, ssl_verify=True):
     """
     Factory method
     """
@@ -154,22 +166,26 @@ def get_view_from_url(url, username=None, password=None):
     if not matched:
         raise BadURL("Cannot parse URL %s" % url)
     jenkinsurl, view_name = matched.groups()
-    jenkinsci = Jenkins(jenkinsurl, username=username, password=password)
+    jenkinsci = Jenkins(jenkinsurl, username=username, password=password,
+                        ssl_verify=ssl_verify)
     return jenkinsci.views[view_name]
 
 
-def get_nested_view_from_url(url, username=None, password=None):
+def get_nested_view_from_url(url, username=None, password=None,
+                             ssl_verify=True):
     """
     Returns View based on provided URL. Convenient for nested views.
     """
     matched = constants.RE_SPLIT_VIEW_URL.search(url)
     if not matched:
         raise BadURL("Cannot parse URL %s" % url)
-    jenkinsci = Jenkins(matched.group(0), username=username, password=password)
+    jenkinsci = Jenkins(matched.group(0), username=username, password=password,
+                        ssl_verify=ssl_verify)
     return jenkinsci.get_view_by_url(url)
 
 
-def install_artifacts(artifacts, dirstruct, installdir, basestaticurl, strict_validation=False):
+def install_artifacts(artifacts, dirstruct, installdir, basestaticurl,
+                      strict_validation=False):
     """
     Install the artifacts.
     """
@@ -198,7 +214,7 @@ def install_artifacts(artifacts, dirstruct, installdir, basestaticurl, strict_va
 
 
 def search_artifact_by_regexp(jenkinsurl, jobid, artifactRegExp,
-                              username=None, password=None):
+                              username=None, password=None, ssl_verify=True):
     '''
     Search the entire history of a hudson job for a build which has an
     artifact whose name matches a supplied regular expression.
@@ -211,7 +227,8 @@ def search_artifact_by_regexp(jenkinsurl, jobid, artifactRegExp,
     @param username: Jenkins login user name, optional
     @param password: Jenkins login password, optional
     '''
-    job = Jenkins(jenkinsurl, username=username, password=password)
+    job = Jenkins(jenkinsurl, username=username, password=password,
+                  ssl_verify=ssl_verify)
     j = job[jobid]
 
     build_ids = j.get_build_ids()

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -42,7 +42,8 @@ class Jenkins(JenkinsBase):
     def __init__(
             self, baseurl,
             username=None, password=None,
-            requester=None, lazy=False):
+            requester=None, lazy=False,
+            ssl_verify=True):
         """
         :param baseurl: baseurl for jenkins instance including port, str
         :param username: username for jenkins auth, str
@@ -54,7 +55,8 @@ class Jenkins(JenkinsBase):
         self.requester = requester or Requester(
             username,
             password,
-            baseurl=baseurl)
+            baseurl=baseurl,
+            ssl_verify=ssl_verify)
         self.lazy = lazy
         JenkinsBase.__init__(self, baseurl, poll=not lazy)
 
@@ -383,7 +385,8 @@ class Jenkins(JenkinsBase):
         # here can be 503 even when everything is normal
         url = '%s/safeRestart' % (self.baseurl,)
         valid = self.requester.VALID_STATUS_CODES + [503]
-        resp = self.requester.post_and_confirm_status(url, data='', valid=valid)
+        resp = self.requester.post_and_confirm_status(url, data='',
+                                                      valid=valid)
         return resp
 
     def get_plugins(self, depth=1):


### PR DESCRIPTION
There are times when one doesn't want to verify the jenkins master certificate.
Although, this can be done by passing such a requester, ssl_verify argument
will do the job and make the code more readable.