### PR TITLE
Credentials and ssh nodes

### DIFF
--- a/jenkinsapi/__init__.py
+++ b/jenkinsapi/__init__.py
@@ -63,7 +63,6 @@ __all__ = [
     "fingerprint", "jenkins", "jenkinsbase", "job", "node", "result_set", "result", "view"
 ]
 __docformat__ = "epytext"
-import sys
 # In case of jenkinsapi is not installed in 'develop' mode
 if not sys.argv[0].endswith('nosetests'):
     __version__ = pkg_resources.working_set.by_key['jenkinsapi'].version

--- a/jenkinsapi/__init__.py
+++ b/jenkinsapi/__init__.py
@@ -63,7 +63,7 @@ __all__ = [
     "fingerprint", "jenkins", "jenkinsbase", "job", "node", "result_set", "result", "view"
 ]
 __docformat__ = "epytext"
-
+import sys
 # In case of jenkinsapi is not installed in 'develop' mode
 if not sys.argv[0].endswith('nosetests'):
     __version__ = pkg_resources.working_set.by_key['jenkinsapi'].version

--- a/jenkinsapi/credential.py
+++ b/jenkinsapi/credential.py
@@ -1,0 +1,48 @@
+"""
+Module for jenkinsapi Credential class
+"""
+
+from jenkinsapi.jenkinsbase import JenkinsBase
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class Credential(JenkinsBase):
+    """
+    Class to hold information on credentials
+
+    This class doesn't hold any username/password information
+    You can create Credential instance with username and password,
+    but the those fields will be cleared once credentials are loaded from
+    Jenkins
+    """
+    def __init__(self, username=None, password=None):
+        """
+        Init a credential object by providing all relevant pointers to it
+
+        :param credential_id: Jenkins internal credential ID
+        :param description: as Jenkins doesn't allow human friendly names for credentials
+            and makes "displayName" itself, there is no way to find credential later,
+            this field is used to distinguish between credentials
+        :param fullname: Jenkins internal name,
+            like 'credential-store/_/79972988-efd6-49f0-b14e-d341251d8d7b'
+        :param typename: Type of the credential
+        :return: Credential obj
+        """
+        self.credential_id = None
+        self.description = None
+        self.fullname = None
+        self.displayname = None
+        self.typename = None
+        self.username = username
+        self.password = password
+
+    def __str__(self):
+        return self.description
+
+
+class UsernamePasswordCredential(Credential):
+    def __init__(self, username=None, password=None):
+        super(UsernamePasswordCredential, self).__init__(username=username,
+                                                         password=password)

--- a/jenkinsapi/credential.py
+++ b/jenkinsapi/credential.py
@@ -1,14 +1,12 @@
 """
 Module for jenkinsapi Credential class
 """
-
-from jenkinsapi.jenkinsbase import JenkinsBase
 import logging
 
 log = logging.getLogger(__name__)
 
 
-class Credential(JenkinsBase):
+class Credential(object):
     """
     Class to hold information on credentials
 
@@ -22,8 +20,9 @@ class Credential(JenkinsBase):
         Init a credential object by providing all relevant pointers to it
 
         :param credential_id: Jenkins internal credential ID
-        :param description: as Jenkins doesn't allow human friendly names for credentials
-            and makes "displayName" itself, there is no way to find credential later,
+        :param description: as Jenkins doesn't allow human friendly names
+            for credentials and makes "displayName" itself,
+            there is no way to find credential later,
             this field is used to distinguish between credentials
         :param fullname: Jenkins internal name,
             like 'credential-store/_/79972988-efd6-49f0-b14e-d341251d8d7b'
@@ -35,6 +34,8 @@ class Credential(JenkinsBase):
         self.fullname = None
         self.displayname = None
         self.typename = None
+        # TODO: lechat 15/01/11 - those two fields must be moved to
+        # UsernamePasswordCredential
         self.username = username
         self.password = password
 
@@ -43,6 +44,10 @@ class Credential(JenkinsBase):
 
 
 class UsernamePasswordCredential(Credential):
+    """
+    This class marks that credential type is username and password
+
+    """
     def __init__(self, username=None, password=None):
         super(UsernamePasswordCredential, self).__init__(username=username,
                                                          password=password)

--- a/jenkinsapi/credentials.py
+++ b/jenkinsapi/credentials.py
@@ -1,0 +1,181 @@
+"""
+This module implements the Credentials class, which is intended to be a
+container-like interface for all of the Global credentials defined on a single
+Jenkins node.
+"""
+import logging
+import urllib
+from jenkinsapi.credential import Credential
+from jenkinsapi.credential import UsernamePasswordCredential
+from jenkinsapi.jenkinsbase import JenkinsBase
+from jenkinsapi.custom_exceptions import JenkinsAPIException
+
+log = logging.getLogger(__name__)
+
+
+class Credentials(JenkinsBase):
+    """
+    This class provides a container-like API which gives
+    access to all global credentials on a Jenkins node.
+
+    Returns a list of Credential Objects.
+    """
+    def __init__(self, baseurl, jenkins_obj):
+        self.baseurl = baseurl
+        self.jenkins = jenkins_obj
+        JenkinsBase.__init__(self, baseurl)
+
+        self.credentials = self._data['credentials']
+
+    def _poll(self, tree=None):
+        url = self.python_api_url(self.baseurl)
+        data = self.get_data(url, tree=tree)
+        credentials = data['credentials']
+        for cred_id in credentials.keys():
+            cred_url = self.python_api_url('%s/credential/%s' % (self.baseurl, cred_id))
+            cred_dict = self.get_data(cred_url)
+
+            cr = None
+            if cred_dict['typeName'] == 'Username with password':
+                cr = UsernamePasswordCredential(None, None)
+            else:
+                cr = Credential(None, None)
+
+            cr.credential_id = cred_id
+            cr.description = cred_dict['description']
+            cr.fullname = cred_dict['fullName']
+            cr.typename = cred_dict['typeName']
+            cr.displayname = cred_dict['displayName']
+            credentials[cred_id] = cr
+
+        return data
+
+    def __str__(self):
+        return 'Global Credentials @ %s' % self.baseurl
+
+    def get_jenkins_obj(self):
+        return self.jenkins
+
+    def __iter__(self):
+        for cred in self.credentials.itervalues():
+            yield cred.description
+
+    def __contains__(self, description):
+        return description in self.keys()
+
+    def iterkeys(self):
+        return self.__iter__()
+
+    def keys(self):
+        return list(self.iterkeys())
+
+    def iteritems(self):
+        for cred in self.credentials.itervalues():
+            yield cred.description, cred
+
+    def __getitem__(self, description):
+        for cred in self.credentials.itervalues():
+            if cred.description == description:
+                return cred
+
+        raise KeyError('Credential with description "%s" not found'
+                        % description)
+
+    def __len__(self):
+        return len(self.keys())
+
+    def __setitem__(self, description, credential):
+        """
+        Creates Credential in Jenkins using username, password and description
+        Description must be unique in Jenkins instance
+        because it is used to find Credential later.
+
+        If description already exists - this method is going to update existing Credential
+
+        :param str description: Credential description
+        :param tuple credential_tuple: (username, password, description) tuple.
+        """
+        if description not in self:
+            if isinstance(credential, UsernamePasswordCredential):
+                params = {
+                    # 'stapler-class': 'com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl',
+                    # '_.id': '',
+                    # 'keyStoreSource': '0',
+                    # '_.keyStoreFile': '',
+                    # 'stapler-class': 'com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl%24FileOnMasterKeyStoreSource',
+                    # '_.uploadedKeystore': ' ',
+                    # 'stapler-class': 'com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl%24UploadedKeyStoreSource',
+                    # '_.password': ' ',
+                    # '_.description': ' ',
+                    # 'stapler-class': 'com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPassword',
+                    # '_.id': ' ',
+                    # '_.username': username,
+                    # '_.password': password,
+                    # '_.description': description,
+                    # 'stapler-class': 'com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey',
+                    'stapler-class': 'com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl',
+                    'Submit': 'OK',
+                    'json': {
+                        "": "1",
+                        "credentials": {
+                            "stapler-class": "com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl",
+                            "id": "",
+                            "username": credential.username,
+                            "password": credential.password,
+                            "description": description
+                        }}
+                    }
+            url = '%s/credential-store/domain/_/createCredentials' % self.jenkins.baseurl
+        else:
+            # update existing credentials
+            cred = self[description]
+            if isinstance(cred, UsernamePasswordCredential):
+                params = {
+                    'stapler-class': 'com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl',
+                    '_.id': cred.credential_id,
+                    '_.username': cred.username,
+                    '_.password': cred.password,
+                    '_.description': description,
+                    'json': {
+                        "stapler-class": "com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl",
+                        "id": cred.credential_id,
+                        "username": cred.username,
+                        "password": cred.password,
+                        "description": description
+                    },
+                    'Submit': 'Save'
+                }
+            url = '%s/credential-store/domain/_/credential/%s/updateSubmit' \
+                % (self.jenkins.baseurl, cred.credential_id)
+
+        try:
+            self.jenkins.requester.post_and_confirm_status(url, params={}, data=urllib.urlencode(params))
+        except HTTPError:
+            raise JenkinsAPIException('Latest version of Credentials '
+                                      'plugin is required to be able '
+                                      'to create/update credentials')
+        self.poll()
+        self.credentials = self._data['credentials']
+        if description not in self:
+            raise JenkinsAPIException('Problem creating/updating credential.')
+
+    def get(self, item, default):
+        return self[item] if item in self else default
+
+    def __delitem__(self, description):
+        params = {
+            'Submit': 'OK',
+            'json': {}
+        }
+        url = ('%s/credential-store/domain/_/credential/%s/doDelete'
+               % (self.jenkins.baseurl, self[description].credential_id))
+        try:
+            self.jenkins.requester.post_and_confirm_status(url, params={}, data=urllib.urlencode(params))
+        except HTTPError:
+            raise JenkinsAPIException('Latest version of Credentials '
+                                      'required to be able to create '
+                                      'credentials')
+        self.poll()
+        self.credentials = self._data['credentials']
+        if description in self:
+            raise JenkinsAPIException('Problem deleting credential.')

--- a/jenkinsapi/custom_exceptions.py
+++ b/jenkinsapi/custom_exceptions.py
@@ -151,3 +151,10 @@ class BadParams(JenkinsAPIException):
     """Invocation was given bad or inappropriate params
     """
     pass
+
+
+class AlreadyExists(JenkinsAPIException):
+    """
+    Method requires POST and not GET
+    """
+    pass

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -16,6 +16,7 @@ except ImportError:
 import logging
 
 from jenkinsapi import config
+from jenkinsapi.credentials import Credentials
 from jenkinsapi.executors import Executors
 from jenkinsapi.job import Job
 from jenkinsapi.jobs import Jobs
@@ -412,3 +413,10 @@ class Jenkins(JenkinsBase):
         response = self.requester.get_and_confirm_status(self.baseurl)
         version_key = 'X-Jenkins'
         return response.headers.get(version_key, '0.0')
+
+    def get_credentials(self):
+        """
+        Return credentials
+        """
+        url = '%s/credential-store/domain/_/' % self.baseurl
+        return Credentials(url, self)

--- a/jenkinsapi/nodes.py
+++ b/jenkinsapi/nodes.py
@@ -2,10 +2,13 @@
 Module for jenkinsapi nodes
 """
 
+import json
 import logging
+import urllib
 from jenkinsapi.node import Node
-from jenkinsapi.custom_exceptions import UnknownNode
 from jenkinsapi.jenkinsbase import JenkinsBase
+from jenkinsapi.custom_exceptions import JenkinsAPIException
+from jenkinsapi.custom_exceptions import UnknownNode
 
 log = logging.getLogger(__name__)
 
@@ -46,7 +49,11 @@ class Nodes(JenkinsBase):
                 nodeurl = '%s/(%s)' % (self.baseurl, nodename)
             else:
                 nodeurl = '%s/%s' % (self.baseurl, nodename)
-            yield item['displayName'], Node(nodeurl, nodename, self.jenkins)
+            try:
+                yield item['displayName'], Node(nodeurl,
+                                                nodename, self.jenkins)
+            except Exception:
+                raise JenkinsAPIException('Unable to iterate nodes')
 
     def __getitem__(self, nodename):
         self_as_dict = dict(self.iteritems())
@@ -57,3 +64,82 @@ class Nodes(JenkinsBase):
 
     def __len__(self):
         return len(self.iteritems())
+
+    def create_node(self, name, num_executors=2, node_description=None,
+                    remote_fs='/var/lib/jenkins', labels=None,
+                    exclusive=False, host=None, port=None,
+                    credential_descr=None, jvm_options='',
+                    java_path=None, prefix_start_slave_cmd='',
+                    suffix_start_slave_cmd=''):
+        """
+        Create a new slave node via SSH.
+
+        :param name: fqdn of slave, str
+        :param num_executors: number of executors, int
+        :param node_description: a freetext field describing the node
+        :param remote_fs: jenkins path, str
+        :param labels: labels to associate with slave, str
+        :param exclusive: tied to specific job, boolean
+        :param host: slave server's host name
+        :param port: slave server's port
+        :param credential_descr: jenkins credential description field
+        :param jvm_options: specify JVM options needed when launching java
+        :param java_path: java path
+        :param prefix_start_slave_cmd: prefix start slave command
+        :param suffix_start_slave_cmd: suffix start slave command
+        :return: node obj
+        """
+        NODE_TYPE = 'hudson.slaves.DumbSlave$DescriptorImpl'
+        MODE = 'NORMAL'
+        if name in self:
+            return self[name]
+
+        if exclusive:
+            MODE = 'EXCLUSIVE'
+        if not credential_descr:
+            launcher = {'stapler-class': 'hudson.slaves.JNLPLauncher'}
+        else:
+            credential = self.jenkins.credentials.get(credential_descr, None)
+            if not credential:
+                raise JenkinsAPIException('Credential with description "%s" '
+                                          'not found' % credential_descr)
+            launcher = {
+                'stapler-class': 'hudson.plugins.sshslaves.SSHLauncher',
+                'host': host,
+                'port': port,
+                'credentialsId': credential.credential_id,
+                'jvmOptions': jvm_options,
+                'javaPath': java_path,
+                'prefixStartSlaveCmd': prefix_start_slave_cmd,
+                'suffixStartSlaveCmd': suffix_start_slave_cmd
+            }
+
+        params = {
+            'name': name,
+            'type': NODE_TYPE,
+            'json': json.dumps({
+                'name': name,
+                'nodeDescription': node_description,
+                'numExecutors': num_executors,
+                'remoteFS': remote_fs,
+                'labelString': labels,
+                'mode': MODE,
+                'type': NODE_TYPE,
+                'retentionStrategy': {'stapler-class':
+                                      'hudson.slaves.'
+                                      'RetentionStrategy$Always'},
+                'nodeProperties': {'stapler-class-bag': 'true'},
+                'launcher': launcher
+            })
+        }
+        url = self.jenkins.get_node_url() + "doCreateItem?%s" % \
+            urllib.urlencode(params)
+        self.jenkins.requester.get_and_confirm_status(url)
+        self.poll()
+        return self[name]
+
+    def __delitem__(self, item):
+        if item in self and item != 'master':
+            url = "%s/doDelete" % self[item].baseurl
+            self.jenkins.requester.get_and_confirm_status(url)
+            self.poll()

--- a/jenkinsapi_tests/systests/__init__.py
+++ b/jenkinsapi_tests/systests/__init__.py
@@ -6,7 +6,8 @@ state = {}
 # Extra plugins required by the systests
 PLUGIN_DEPENDENCIES = ["http://updates.jenkins-ci.org/latest/git.hpi",
                        "http://updates.jenkins-ci.org/latest/git-client.hpi",
-                       "https://updates.jenkins-ci.org/latest/nested-view.hpi"]
+                       "https://updates.jenkins-ci.org/latest/nested-view.hpi",
+                       "https://updates.jenkins-ci.org/latest/ssh-slaves.hpi"]
 
 
 def setUpPackage():

--- a/jenkinsapi_tests/systests/test_credentials.py
+++ b/jenkinsapi_tests/systests/test_credentials.py
@@ -1,0 +1,66 @@
+'''
+System tests for `jenkinsapi.jenkins` module.
+'''
+import logging
+# To run unittests on python 2.6 please use unittest2 library
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+from jenkinsapi_tests.systests.base import BaseSystemTest
+from jenkinsapi_tests.test_utils.random_strings import random_string
+from jenkinsapi.credentials import Credentials
+from jenkinsapi.credential import UsernamePasswordCredential
+
+log = logging.getLogger(__name__)
+
+
+class TestCredentials(BaseSystemTest):
+    def test_get_credentials(self):
+        creds = self.jenkins.get_credentials()
+        self.assertIsInstance(creds, Credentials)
+
+    def test_delete_inexistant_credential(self):
+        with self.assertRaises(KeyError) as ke:
+            creds = self.jenkins.get_credentials()
+
+            del creds[random_string()]
+
+    def test_create_credential(self):
+        creds = self.jenkins.get_credentials()
+
+        cred_descr = random_string()
+        creds[cred_descr] = UsernamePasswordCredential('username', 'password')
+
+        self.assertTrue(cred_descr in creds)
+        cred = creds[cred_descr]
+        self.assertIsInstance(cred, UsernamePasswordCredential)
+        self.assertEquals(cred.password, None)
+        self.assertEquals(cred.description, cred_descr)
+
+    def test_delete_credential(self):
+        creds = self.jenkins.get_credentials()
+
+        cred_descr = random_string()
+        creds[cred_descr] = UsernamePasswordCredential('username', 'password')
+
+        del creds[cred_descr]
+
+    def test_update_credential(self):
+        creds = self.jenkins.get_credentials()
+
+        cred_descr = random_string()
+        creds[cred_descr] = UsernamePasswordCredential('username', 'password')
+
+        cred = creds[cred_descr]
+        cred.username = 'anotheruser'
+        cred.password = 'password'
+
+        creds[cred_descr] = cred
+
+        self.assertIn('anotheruser', creds[cred_descr].displayname)
+
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    unittest.main()

--- a/jenkinsapi_tests/systests/test_credentials.py
+++ b/jenkinsapi_tests/systests/test_credentials.py
@@ -11,26 +11,33 @@ from jenkinsapi_tests.systests.base import BaseSystemTest
 from jenkinsapi_tests.test_utils.random_strings import random_string
 from jenkinsapi.credentials import Credentials
 from jenkinsapi.credential import UsernamePasswordCredential
+from jenkinsapi.credential import SSHKeyCredential
+from jenkinsapi.custom_exceptions import JenkinsAPIException
 
 log = logging.getLogger(__name__)
 
 
 class TestCredentials(BaseSystemTest):
     def test_get_credentials(self):
-        creds = self.jenkins.get_credentials()
+        creds = self.jenkins.credentials
         self.assertIsInstance(creds, Credentials)
 
     def test_delete_inexistant_credential(self):
-        with self.assertRaises(KeyError) as ke:
-            creds = self.jenkins.get_credentials()
+        with self.assertRaises(KeyError):
+            creds = self.jenkins.credentials
 
             del creds[random_string()]
 
-    def test_create_credential(self):
-        creds = self.jenkins.get_credentials()
+    def test_create_user_pass_credential(self):
+        creds = self.jenkins.credentials
 
         cred_descr = random_string()
-        creds[cred_descr] = UsernamePasswordCredential('username', 'password')
+        cred_dict = {
+            'description': cred_descr,
+            'userName': 'userName',
+            'password': 'password'
+        }
+        creds[cred_descr] = UsernamePasswordCredential(cred_dict)
 
         self.assertTrue(cred_descr in creds)
         cred = creds[cred_descr]
@@ -38,27 +45,96 @@ class TestCredentials(BaseSystemTest):
         self.assertEquals(cred.password, None)
         self.assertEquals(cred.description, cred_descr)
 
-    def test_delete_credential(self):
-        creds = self.jenkins.get_credentials()
+        del creds[cred_descr]
+
+    def test_update_user_pass_credential(self):
+        creds = self.jenkins.credentials
 
         cred_descr = random_string()
-        creds[cred_descr] = UsernamePasswordCredential('username', 'password')
+        cred_dict = {
+            'description': cred_descr,
+            'userName': 'userName',
+            'password': 'password'
+        }
+        creds[cred_descr] = UsernamePasswordCredential(cred_dict)
+
+        cred = creds[cred_descr]
+        cred.userName = 'anotheruser'
+        cred.password = 'password'
+
+        with self.assertRaises(JenkinsAPIException):
+            creds[cred_descr] = cred
+
+    def test_create_ssh_credential(self):
+        creds = self.jenkins.credentials
+
+        cred_descr = random_string()
+        cred_dict = {
+            'description': cred_descr,
+            'userName': 'userName',
+            'passphrase': '',
+            'private_key': '-----BEGIN RSA PRIVATE KEY-----'
+        }
+        creds[cred_descr] = SSHKeyCredential(cred_dict)
+
+        self.assertTrue(cred_descr in creds)
+        cred = creds[cred_descr]
+        self.assertIsInstance(cred, SSHKeyCredential)
+        self.assertEquals(cred.description, cred_descr)
 
         del creds[cred_descr]
 
-    def test_update_credential(self):
-        creds = self.jenkins.get_credentials()
+        cred_dict = {
+            'description': cred_descr,
+            'userName': 'userName',
+            'passphrase': '',
+            'private_key': '/tmp/key'
+        }
+        creds[cred_descr] = SSHKeyCredential(cred_dict)
+
+        self.assertTrue(cred_descr in creds)
+        cred = creds[cred_descr]
+        self.assertIsInstance(cred, SSHKeyCredential)
+        self.assertEquals(cred.description, cred_descr)
+
+        del creds[cred_descr]
+
+        cred_dict = {
+            'description': cred_descr,
+            'userName': 'userName',
+            'passphrase': '',
+            'private_key': '~/.ssh/key'
+        }
+        creds[cred_descr] = SSHKeyCredential(cred_dict)
+
+        self.assertTrue(cred_descr in creds)
+        cred = creds[cred_descr]
+        self.assertIsInstance(cred, SSHKeyCredential)
+        self.assertEquals(cred.description, cred_descr)
+
+        del creds[cred_descr]
+
+        cred_dict = {
+            'description': cred_descr,
+            'userName': 'userName',
+            'passphrase': '',
+            'private_key': 'invalid'
+        }
+        with self.assertRaises(ValueError):
+            creds[cred_descr] = SSHKeyCredential(cred_dict)
+
+    def test_delete_credential(self):
+        creds = self.jenkins.credentials
 
         cred_descr = random_string()
-        creds[cred_descr] = UsernamePasswordCredential('username', 'password')
+        cred_dict = {
+            'description': cred_descr,
+            'userName': 'userName',
+            'password': 'password'
+        }
+        creds[cred_descr] = UsernamePasswordCredential(cred_dict)
 
-        cred = creds[cred_descr]
-        cred.username = 'anotheruser'
-        cred.password = 'password'
-
-        creds[cred_descr] = cred
-
-        self.assertIn('anotheruser', creds[cred_descr].displayname)
+        del creds[cred_descr]
 
 
 if __name__ == '__main__':

--- a/jenkinsapi_tests/systests/test_executors.py
+++ b/jenkinsapi_tests/systests/test_executors.py
@@ -21,7 +21,14 @@ class TestNodes(BaseSystemTest):
 
     def test_get_executors(self):
         node_name = random_string()
-        self.jenkins.create_node(node_name)
+        node_dict = {
+            'num_executors': 2,
+            'node_description': 'Test JNLP Node',
+            'remote_fs': '/tmp',
+            'labels': 'systest_jnlp',
+            'exclusive': True
+        }
+        self.jenkins.nodes.create_node(node_name, node_dict)
         executors = self.jenkins.get_executors(node_name)
         self.assertEqual(executors.count, 2)
         for count, execs in enumerate(executors):
@@ -30,7 +37,14 @@ class TestNodes(BaseSystemTest):
 
     def test_running_executor(self):
         node_name = random_string()
-        self.jenkins.create_node(node_name)
+        node_dict = {
+            'num_executors': 1,
+            'node_description': 'Test JNLP Node',
+            'remote_fs': '/tmp',
+            'labels': 'systest_jnlp',
+            'exclusive': True
+        }
+        self.jenkins.nodes.create_node(node_name, node_dict)
         job_name = 'create_%s' % random_string()
         job = self.jenkins.create_job(job_name, LONG_RUNNING_JOB)
         qq = job.invoke()
@@ -55,7 +69,14 @@ class TestNodes(BaseSystemTest):
 
     def test_idle_executors(self):
         node_name = random_string()
-        self.jenkins.create_node(node_name)
+        node_dict = {
+            'num_executors': 1,
+            'node_description': 'Test JNLP Node',
+            'remote_fs': '/tmp',
+            'labels': 'systest_jnlp',
+            'exclusive': True
+        }
+        self.jenkins.nodes.create_node(node_name, node_dict)
         executors = self.jenkins.get_executors(node_name)
 
         for execs in executors:

--- a/jenkinsapi_tests/systests/test_nodes.py
+++ b/jenkinsapi_tests/systests/test_nodes.py
@@ -7,6 +7,8 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
+from jenkinsapi.node import Node
+from jenkinsapi.credential import UsernamePasswordCredential
 from jenkinsapi_tests.systests.base import BaseSystemTest
 from jenkinsapi_tests.test_utils.random_strings import random_string
 
@@ -14,19 +16,6 @@ log = logging.getLogger(__name__)
 
 
 class TestNodes(BaseSystemTest):
-
-    def test_invoke_job_parameterized(self):
-        node_name = "param_" + random_string()
-        try:
-            self.jenkins.create_node(node_name)
-            self.assertTrue(self.jenkins.has_node(node_name))
-
-            N = self.jenkins.get_node(node_name)
-            self.assertEquals(N.baseurl, self.jenkins.get_node_url(node_name))
-
-        finally:
-            self.jenkins.delete_node(node_name)
-            self.assertFalse(self.jenkins.has_node(node_name))
 
     def test_online_offline(self):
         """
@@ -46,6 +35,60 @@ class TestNodes(BaseSystemTest):
 
         mn.set_online()  # Switch it back on
         self.assertTrue(mn.is_online())
+
+    def test_create_jnlp_node(self):
+        node_name = random_string()
+        node = self.jenkins.create_node(node_name, 2, 'test')
+
+        self.assertTrue(isinstance(node, Node))
+
+        node2 = self.jenkins.create_node(node_name, 2, 'test')
+        self.assertEquals(node, node2)
+
+    def test_create_ssh_node(self):
+        node_name = random_string()
+        creds = self.jenkins.get_credentials()
+
+        cred_descr = random_string()
+        creds[cred_descr] = UsernamePasswordCredential('username', 'password')
+        node_dict = {
+            'num_executors': 1,
+            'node_description': 'Description %s' % node_name,
+            'remote_fs': '/tmp',
+            'labels': node_name,
+            'exclusive': False,
+            'host': 'localhost',
+            'port': 22,
+            'credential_description': cred_descr,
+            'jvm_options': '',
+            'java_path': '',
+            'prefix_start_slave_cmd': '',
+            'suffix_start_slave_cmd': ''
+        }
+        self.jenkins.nodes[node_name] = Node(baseurl=None,
+                                             nodename=node_name,
+                                             jenkins_obj=self.jenkins,
+                                             node_dict=node_dict)
+
+        node = self.jenkins.nodes[node_name]
+
+        self.assertTrue(isinstance(node, Node))
+
+    def test_delete_node(self):
+        node_name = random_string()
+        self.jenkins.create_node(node_name, 2, 'test')
+        del self.jenkins.nodes[node_name]
+
+        with self.assertRaises(KeyError):
+            self.jenkins.nodes[node_name]
+
+    def test_delete_all_nodes(self):
+        nodes = self.jenkins.nodes
+
+        for name in nodes.keys():
+            del nodes[name]
+
+        self.assertTrue(len(self.jenkins.nodes) == 1)
 
 
 if __name__ == '__main__':

--- a/jenkinsapi_tests/systests/test_nodes.py
+++ b/jenkinsapi_tests/systests/test_nodes.py
@@ -38,12 +38,17 @@ class TestNodes(BaseSystemTest):
 
     def test_create_jnlp_node(self):
         node_name = random_string()
-        node = self.jenkins.create_node(node_name, 2, 'test')
-
+        node_dict = {
+            'num_executors': 1,
+            'node_description': 'Test JNLP Node',
+            'remote_fs': '/tmp',
+            'labels': 'systest_jnlp',
+            'exclusive': True
+        }
+        node = self.jenkins.nodes.create_node(node_name, node_dict)
         self.assertTrue(isinstance(node, Node))
 
-        node2 = self.jenkins.create_node(node_name, 2, 'test')
-        self.assertEquals(node, node2)
+        del self.jenkins.nodes[node_name]
 
     def test_create_ssh_node(self):
         node_name = random_string()
@@ -63,24 +68,36 @@ class TestNodes(BaseSystemTest):
             'jvm_options': '',
             'java_path': '',
             'prefix_start_slave_cmd': '',
-            'suffix_start_slave_cmd': ''
+            'suffix_start_slave_cmd': '',
+            'retention': 'ondemand',
+            'ondemand_delay': 0,
+            'ondemand_idle_delay': 5
         }
-        self.jenkins.nodes[node_name] = Node(baseurl=None,
-                                             nodename=node_name,
-                                             jenkins_obj=self.jenkins,
-                                             node_dict=node_dict)
-
-        node = self.jenkins.nodes[node_name]
-
+        node = self.jenkins.nodes.create_node(node_name, node_dict)
         self.assertTrue(isinstance(node, Node))
+        del self.jenkins.nodes[node_name]
+
+        self.jenkins.nodes[node_name] = node_dict
+        self.assertTrue(isinstance(self.jenkins.nodes[node_name], Node))
+        del self.jenkins.nodes[node_name]
 
     def test_delete_node(self):
         node_name = random_string()
-        self.jenkins.create_node(node_name, 2, 'test')
+        node_dict = {
+            'num_executors': 1,
+            'node_description': 'Test JNLP Node',
+            'remote_fs': '/tmp',
+            'labels': 'systest_jnlp',
+            'exclusive': True
+        }
+        self.jenkins.nodes.create_node(node_name, node_dict)
         del self.jenkins.nodes[node_name]
 
         with self.assertRaises(KeyError):
             self.jenkins.nodes[node_name]
+
+        with self.assertRaises(KeyError):
+            del self.jenkins.nodes['not_exist']
 
     def test_delete_all_nodes(self):
         nodes = self.jenkins.nodes

--- a/jenkinsapi_tests/systests/test_nodes.py
+++ b/jenkinsapi_tests/systests/test_nodes.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     import unittest
 from jenkinsapi.node import Node
-from jenkinsapi.credential import UsernamePasswordCredential
+from jenkinsapi.credential import SSHKeyCredential
 from jenkinsapi_tests.systests.base import BaseSystemTest
 from jenkinsapi_tests.test_utils.random_strings import random_string
 
@@ -55,7 +55,13 @@ class TestNodes(BaseSystemTest):
         creds = self.jenkins.get_credentials()
 
         cred_descr = random_string()
-        creds[cred_descr] = UsernamePasswordCredential('username', 'password')
+        cred_dict = {
+            'description': cred_descr,
+            'userName': 'username',
+            'passphrase': '',
+            'private_key': '~'
+        }
+        creds[cred_descr] = SSHKeyCredential(cred_dict)
         node_dict = {
             'num_executors': 1,
             'node_description': 'Description %s' % node_name,

--- a/jenkinsapi_tests/unittests/test_node.py
+++ b/jenkinsapi_tests/unittests/test_node.py
@@ -41,7 +41,7 @@ class TestNode(unittest.TestCase):
         # def __init__(self, baseurl, nodename, jenkins_obj):
 
         self.J = mock.MagicMock()  # Jenkins object
-        self.n = Node('http://', 'bobnit', self.J)
+        self.n = Node(self.J, 'http://', 'bobnit', {})
 
     def testRepr(self):
         # Can we produce a repr string for this object


### PR DESCRIPTION
This change adds:

- Credentials class - for operations on Jenkins credentials
- UsernamePasswordCredential - to hold username and password credentials
- SSHKeyCredential - for ssh key credentials
- ability to create ssh slaves

JNLP slave creation was unified with SSH slaves, so both have similar way of making them.