### PR TITLE
Decoding bytes with the ISO-8859-1 encoding

### DIFF
--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -413,6 +413,8 @@ class Build(JenkinsBase):
         if isinstance(content, str):
             return content
         elif isinstance(content, bytes):
+            return content.decode('ISO-8859-1')
+        elif isinstance(content, bytes):
             return content.decode('utf-8')
         else:
             raise JenkinsAPIException('Unknown content type for console')

--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -414,8 +414,6 @@ class Build(JenkinsBase):
             return content
         elif isinstance(content, bytes):
             return content.decode('ISO-8859-1')
-        elif isinstance(content, bytes):
-            return content.decode('utf-8')
         else:
             raise JenkinsAPIException('Unknown content type for console')
 


### PR DESCRIPTION
Hey here is the patch for the issue #396 I created. Jenkins uses the ISO-8859-1 as an encoding so using it to decode the byte streams worked. Thanks.