### PR TITLE
Fixed EMPTY_JOB config to match the one returned from Jenkins

### DIFF
--- a/jenkinsapi_tests/systests/job_configs.py
+++ b/jenkinsapi_tests/systests/job_configs.py
@@ -3,10 +3,9 @@ A selection of job objects used in testing.
 """
 
 EMPTY_JOB = '''\
-<?xml version='1.0' encoding='UTF-8'?>
-<project>
+<?xml version="1.0" encoding="UTF-8"?><project>
   <actions/>
-  <description></description>
+  <description/>
   <keepDependencies>false</keepDependencies>
   <properties/>
   <scm class="hudson.scm.NullSCM"/>


### PR DESCRIPTION
For some reason latest Jenkins versions format job's config.xml a bit different. This is to fix our formatting, so the test will pass.