### PR TITLE
Update setup.py classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
         'Topic :: Software Development :: Testing',
     ],
 )


### PR DESCRIPTION
The classifiers are used by PyPI to recognize Python 3 compatible packages (also by caniusepython3.com and developers).