### PR TITLE
Update setup.cfg to support universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,6 @@ upload-dir = doc/build/html
 detailed-errors = 1
 with-coverage = 1
 cover-package = jenkinsapi
+
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
jenkinsapi already uploads wheel distributions. Since jenkinsapi is pure Python and supports both Python 2 and 3, it should use "universal wheels". Otherwise the wheel distribution will not be used on all supported platforms.
See: http://python-packaging-user-guide.readthedocs.org/en/latest/distributing/#universal-wheels
and http://pythonwheels.com/