### PR TITLE
Add jenkinsapi.Node.get_labels()

### DIFF
--- a/jenkinsapi_tests/systests/test_nodes.py
+++ b/jenkinsapi_tests/systests/test_nodes.py
@@ -113,6 +113,19 @@ class TestNodes(BaseSystemTest):
 
         self.assertTrue(len(self.jenkins.nodes) == 1)
 
+    def test_get_node_labels(self):
+        node_name = random_string()
+        node_labels = 'LABEL1 LABEL2'
+        node_dict = {
+            'num_executors': 1,
+            'node_description': 'Test Node with Labels',
+            'remote_fs': '/tmp',
+            'labels': node_labels,
+            'exclusive': True
+        }
+        node = self.jenkins.create_node(node_name, node_dict)
+        self.assertEquals(node.get_labels(), node_labels)
+
 
 if __name__ == '__main__':
     logging.basicConfig()

--- a/jenkinsapi_tests/systests/test_nodes.py
+++ b/jenkinsapi_tests/systests/test_nodes.py
@@ -123,8 +123,9 @@ class TestNodes(BaseSystemTest):
             'labels': node_labels,
             'exclusive': True
         }
-        node = self.jenkins.create_node(node_name, node_dict)
+        node = self.jenkins.nodes.create_node(node_name, node_dict)
         self.assertEquals(node.get_labels(), node_labels)
+        del self.jenkins.nodes[node_name]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add function to node for querying the labels from the node's config.xml. The config.xml querying and caching was copied from the job's config handling code.

I tried running systests.test_nodes on windows but they all failed so I added the test speculatively. I tried my changes with a real jenkins setup and they work as expected.