### PR TITLE
Proper handling of JENKINS_HOME variable and moving some unit tests into systests

### DIFF
--- a/jenkinsapi_tests/unittests/test_jenkins.py
+++ b/jenkinsapi_tests/unittests/test_jenkins.py
@@ -44,36 +44,6 @@ class TestJenkins(unittest.TestCase):
     @mock.patch.object(JenkinsBase, '_poll')
     @mock.patch.object(Jenkins, '_poll')
     @mock.patch.object(Job, '_poll')
-    def test_get_jobs(self, _base_poll, _poll, _job_poll):
-        _poll.return_value = {
-            'jobs': [
-                {'name': 'job_one',
-                 'url': 'http://localhost:8080/job_one',
-                 'color': 'blue'},
-                {'name': 'job_two',
-                 'url': 'http://localhost:8080/job_two',
-                 'color': 'blue'},
-            ]
-        }
-        _base_poll.return_value = _poll.return_value
-        _job_poll.return_value = {}
-        J = Jenkins('http://localhost:8080/',
-                    username='foouser', password='foopassword')
-        for idx, (job_name, job) in enumerate(J.get_jobs()):
-            self.assertEquals(
-                job_name,
-                _poll.return_value['jobs'][idx]['name'])
-            self.assertTrue(isinstance(job, Job))
-            self.assertEquals(
-                job.name,
-                _poll.return_value['jobs'][idx]['name'])
-            self.assertEquals(
-                job.baseurl,
-                _poll.return_value['jobs'][idx]['url'])
-
-    @mock.patch.object(JenkinsBase, '_poll')
-    @mock.patch.object(Jenkins, '_poll')
-    @mock.patch.object(Job, '_poll')
     def test_lazy_loading(self, _base_poll, _poll, _job_poll):
         _poll.return_value = {
             'jobs': [
@@ -150,93 +120,6 @@ class TestJenkins(unittest.TestCase):
             self.assertEquals(
                 job_name,
                 _poll.return_value['jobs'][idx]['name'])
-
-    @mock.patch.object(JenkinsBase, '_poll')
-    @mock.patch.object(Jenkins, '_poll')
-    @mock.patch.object(Job, '_poll')
-    def test_get_job(self, _base_poll, _poll, _job_poll):
-        _poll.return_value = {
-            'jobs': [
-                {'name': 'job_one',
-                 'url': 'http://localhost:8080/job_one',
-                 'color': 'blue'},
-                {'name': 'job_two',
-                 'url': 'http://localhost:8080/job_two',
-                 'color': 'blue'},
-            ]
-        }
-        _base_poll.return_value = _poll.return_value
-        _job_poll.return_value = {}
-        J = Jenkins('http://localhost:8080/',
-                    username='foouser', password='foopassword')
-        job = J.get_job('job_one')
-        self.assertTrue(isinstance(job, Job))
-        self.assertEquals(job.name, _poll.return_value['jobs'][0]['name'])
-        self.assertEquals(job.baseurl, _poll.return_value['jobs'][0]['url'])
-
-    @mock.patch.object(JenkinsBase, '_poll')
-    @mock.patch.object(Jenkins, '_poll')
-    @mock.patch.object(Job, '_poll')
-    def test_get_job_that_does_not_exist(self, _base_poll, _poll, _job_poll):
-        _poll.return_value = {
-            'jobs': [
-                {'name': 'job_one',
-                 'url': 'http://localhost:8080/job_one',
-                 'color': 'blue'},
-                {'name': 'job_two',
-                 'url': 'http://localhost:8080/job_two',
-                 'color': 'blue'},
-            ]
-        }
-        _base_poll.return_value = _poll.return_value
-        _job_poll.return_value = {}
-        J = Jenkins('http://localhost:8080/',
-                    username='foouser', password='foopassword')
-
-        with self.assertRaises(UnknownJob):
-            job = J.get_job('job_three')
-
-    @mock.patch.object(JenkinsBase, '_poll')
-    @mock.patch.object(Jenkins, '_poll')
-    @mock.patch.object(Job, '_poll')
-    def test_has_job(self, _base_poll, _poll, _job_poll):
-        _poll.return_value = {
-            'jobs': [
-                {'name': 'job_one',
-                 'url': 'http://localhost:8080/job_one',
-                 'color': 'blue'},
-                {'name': 'job_two',
-                 'url': 'http://localhost:8080/job_two',
-                 'color': 'blue'},
-            ]
-        }
-        _base_poll.return_value = _poll.return_value
-        _job_poll.return_value = {}
-        J = Jenkins('http://localhost:8080/',
-                    username='foouser', password='foopassword')
-        job = J.has_job('job_one')
-        self.assertTrue(job)
-
-    @mock.patch.object(JenkinsBase, '_poll')
-    @mock.patch.object(Jenkins, '_poll')
-    @mock.patch.object(Job, '_poll')
-    def test_has_no_job(self, _base_poll, _poll, _job_poll):
-        _poll.return_value = {
-            'jobs': [
-                {'name': 'job_one',
-                 'url': 'http://localhost:8080/job_one',
-                 'color': 'blue'},
-                {'name': 'job_two',
-                 'url': 'http://localhost:8080/job_two',
-                 'color': 'blue'},
-            ]
-        }
-        _base_poll.return_value = _poll.return_value
-        _job_poll.return_value = {}
-        J = Jenkins('http://localhost:8080/',
-                    username='foouser', password='foopassword')
-        job = J.has_job('inexistant_job')
-        self.assertFalse(job)
 
     @mock.patch.object(JenkinsBase, '_poll')
     @mock.patch.object(Jenkins, '_poll')

--- a/jenkinsapi_utils/jenkins_launcher.py
+++ b/jenkinsapi_utils/jenkins_launcher.py
@@ -69,7 +69,11 @@ class JenkinsLancher(object):
             else urlparse(jenkins_url).port
         self.war_path = war_path
         self.war_directory, self.war_filename = os.path.split(self.war_path)
-        self.jenkins_home = tempfile.mkdtemp(prefix='jenkins-home-')
+
+        if 'JENKINS_HOME' not in os.environ:
+            self.jenkins_home = tempfile.mkdtemp(prefix='jenkins-home-')
+            os.environ['JENKINS_HOME'] = self.jenkins_home
+
         self.jenkins_process = None
         self.q = Queue.Queue()
         self.plugin_urls = plugin_urls or []
@@ -119,7 +123,6 @@ class JenkinsLancher(object):
             self.jenkins_process.wait()
             # Do not remove jenkins home if JENKINS_URL is set
             if 'JENKINS_URL' not in os.environ:
-                import pudb; pudb.set_trace()  # XXX BREAKPOINT
                 shutil.rmtree(self.jenkins_home)
 
     def block_until_jenkins_ready(self, timeout):

--- a/jenkinsapi_utils/jenkins_launcher.py
+++ b/jenkinsapi_utils/jenkins_launcher.py
@@ -9,6 +9,7 @@ import shutil
 import logging
 import datetime
 import tempfile
+import posixpath
 import requests
 import threading
 import subprocess
@@ -104,8 +105,8 @@ class JenkinsLancher(object):
 
         log.info("Downloading %s", hpi_url)
         log.info("Plugins will be installed in '%s'", plugin_dir)
-        # FIXME: This is kinda ugly but works
-        filename = "plugin_%s.hpi" % i
+        path = urlparse(hpi_url).path
+        filename = posixpath.basename(path)
         plugin_path = os.path.join(plugin_dir, filename)
         with open(plugin_path, 'wb') as h:
             request = requests.get(hpi_url)
@@ -116,7 +117,10 @@ class JenkinsLancher(object):
             log.info("Shutting down jenkins.")
             self.jenkins_process.terminate()
             self.jenkins_process.wait()
-            shutil.rmtree(self.jenkins_home)
+            # Do not remove jenkins home if JENKINS_URL is set
+            if 'JENKINS_URL' not in os.environ:
+                import pudb; pudb.set_trace()  # XXX BREAKPOINT
+                shutil.rmtree(self.jenkins_home)
 
     def block_until_jenkins_ready(self, timeout):
         start_time = datetime.datetime.now()
@@ -134,11 +138,12 @@ class JenkinsLancher(object):
 
     def start(self, timeout=60):
         if not self.jenkins_url:
+            self.jenkins_home = os.environ.get('JENKINS_HOME',
+                                               self.jenkins_home)
             self.update_war()
             self.update_config()
             self.install_plugins()
 
-            os.environ['JENKINS_HOME'] = self.jenkins_home
             os.chdir(self.war_directory)
 
             jenkins_command = ['java', '-jar', self.war_filename,


### PR DESCRIPTION
I found that if I use `JENKINS_HOME` and 'JENKINS_URL' env variables to run tests, folder where JENKINS_HOME points to gets removed. Fixed that.

Moved some trivial unit tests to systests.