### PR TITLE
Optimizations to reduce amount of data requested from Jenkins

### DIFF
--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -70,6 +70,8 @@ class Job(JenkinsBase, MutableJenkinsThing):
             'hg': self._get_hg_branch,
             None: lambda element_tree: []
         }
+        if url is None:
+            url = jenkins_obj.baseurl + '/job/' + name
         JenkinsBase.__init__(self, url)
 
     def __str__(self):
@@ -667,9 +669,11 @@ class Job(JenkinsBase, MutableJenkinsThing):
         """
         If job has parameters, returns True, else False
         """
-        if any("parameterDefinitions" in a for a in (self._data["actions"]) if a):
+        if any("parameterDefinitions" in a for a in (self._data["actions"])
+               if a):
             return True
-        if any("parameterDefinitions" in a for a in (self._data["property"]) if a):
+        if any("parameterDefinitions" in a for a in (self._data["property"])
+               if a):
             return True
         return False
 

--- a/jenkinsapi/jobs.py
+++ b/jenkinsapi/jobs.py
@@ -20,15 +20,27 @@ class Jobs(object):
 
     def __init__(self, jenkins):
         self.jenkins = jenkins
-        self.jenkins.poll()
+        self._data = []
+
+    def _del_data(self, job_name):
+        if len(self._data) == 0:
+            return
+        for num, job_data in enumerate(self._data):
+            if job_data['name'] == job_name:
+                del self._data[num]
+                return
 
     def __len__(self):
         return len(self.keys())
 
+    def poll(self, tree='jobs[name,color]'):
+        return self.jenkins.poll(tree=tree)
+
     def __delitem__(self, job_name):
         """
         Delete a job by name
-        :param job_name: name of a exist job, str
+        :param str job_name: name of a existing job
+        :raises JenkinsAPIException:  When job is not deleted
         """
         if job_name in self:
             try:
@@ -37,55 +49,59 @@ class Jobs(object):
                     delete_job_url,
                     data='some random bytes...'
                 )
+
+                self._del_data(job_name)
             except JenkinsAPIException:
                 # Sometimes jenkins throws NPE when removing job
                 # It removes job ok, but it is good to be sure
                 # so we re-try if job was not deleted
-                self.jenkins.poll()
                 if job_name in self:
                     delete_job_url = self[job_name].get_delete_url()
                     self.jenkins.requester.post_and_confirm_status(
                         delete_job_url,
                         data='some random bytes...'
                     )
-
-            self.jenkins.poll()
+                    self._del_data(job_name)
 
     def __setitem__(self, key, value):
+        """
+        Create Job
+
+        :param str key:     Job name
+        :param str value:   XML configuration of the job
+
+        .. code-block:: python
+        api = Jenkins('http://localhost:8080/')
+        new_job = api.jobs['my_new_job'] = config_xml
+        """
         return self.create(key, value)
 
     def __getitem__(self, job_name):
-        for row in self.jenkins._data.get('jobs', []):
-            if row['name'] == job_name:
-                return Job(
-                    row['url'],
-                    row['name'],
-                    self.jenkins)
-
-        raise UnknownJob(job_name)
+        if job_name in self:
+            return Job(None, job_name, self.jenkins)
+        else:
+            raise UnknownJob(job_name)
 
     def iteritems(self):
         """
-        Get the names & objects for all jobs
+        Iterate over the names & objects for all jobs
         """
-        self.jenkins.poll()
-        for row in self.jenkins._data.get('jobs', []):
-            name = row['name']
-            url = row['url']
-
-            yield name, Job(url, name, self.jenkins)
+        for job_name in self.iterkeys():
+            yield job_name, Job(None, job_name, self.jenkins)
 
     def __contains__(self, job_name):
         """
-        True if job_name is the name of a defined job
+        True if job_name exists in Jenkins
         """
         return job_name in self.keys()
 
     def iterkeys(self):
         """
-        Get the names of all available views
+        Iterate over the names of all available jobs
         """
-        for row in self.jenkins._data.get('jobs', []):
+        if len(self._data) == 0:
+            self._data = self.poll().get('jobs', [])
+        for row in self._data:
             yield row['name']
 
     def keys(self):
@@ -97,12 +113,16 @@ class Jobs(object):
     def create(self, job_name, config):
         """
         Create a job
-        :param jobname: name of new job, str
-        :param config: configuration of new job, xml
-        :return: new Job obj
+
+        :param str jobname: Name of new job
+        :param str config: XML configuration of new job
+        :returns Job: new Job object
         """
         if job_name in self:
             return self[job_name]
+
+        if config is None or len(config) == 0:
+            raise JenkinsAPIException('Job XML config cannot be empty')
 
         params = {'name': job_name}
         try:
@@ -110,7 +130,7 @@ class Jobs(object):
                     config, unicode):  # pylint: disable=undefined-variable
                 config = str(config)
         except NameError:
-            # Python3 already a str
+            # Python2 already a str
             pass
 
         self.jenkins.requester.post_xml_and_confirm_status(
@@ -118,18 +138,22 @@ class Jobs(object):
             data=config,
             params=params
         )
-        self.jenkins.poll()
-        if job_name not in self:
-            raise JenkinsAPIException('Cannot create job %s' % job_name)
+        # Call above would fail if Jenkins is unhappy
+        # If Jenkins is happy - we don't poll it, but insert job into
+        # internal cache
+        self._data.append({
+            'name': job_name,
+            'color': 'notbuilt'
+        })
 
         return self[job_name]
 
     def copy(self, job_name, new_job_name):
         """
         Copy a job
-        :param job_name: name of a exist job, str
-        :param new_job_name: name of new job, str
-        :return: new Job obj
+        :param str job_name: Name of an existing job
+        :param new_job_name: Name of new job
+        :returns Job: new Job object
         """
         params = {'name': new_job_name,
                   'mode': 'copy',
@@ -139,23 +163,40 @@ class Jobs(object):
             self.jenkins.get_create_url(),
             params=params,
             data='')
-        self.jenkins.poll()
         return self[new_job_name]
 
     def rename(self, job_name, new_job_name):
         """
         Rename a job
-        :param job_name: name of a exist job, str
-        :param new_job_name: name of new job, str
-        :return: new Job obj
+
+        :param str job_name: Name of an existing job
+        :param str new_job_name: Name of new job
+        :returns Job: new Job object
         """
         params = {'newName': new_job_name}
         rename_job_url = self[job_name].get_rename_url()
         self.jenkins.requester.post_and_confirm_status(
             rename_job_url, params=params, data='')
-        self.jenkins.poll()
+
+        self._data.append({
+            'name': new_job_name,
+            'color': 'notbuilt'
+        })
+        self._del_data(job_name)
+
         return self[new_job_name]
 
-    def build(self, job_name, params):
-        assert isinstance(params, dict)
-        self[job_name].invoke(build_params=params)
+    def build(self, job_name, params=None, **kwargs):
+        """
+        Executes build of a job
+
+        :param str job_name:    Job name
+        :param dict params:     Job parameters
+        :param kwargs:          Parameters for Job.invoke() function
+        :returns QueueItem:     Object to track build progress
+        """
+        if params is not None:
+            assert isinstance(params, dict)
+            return self[job_name].invoke(build_params=params, **kwargs)
+        else:
+            return self[job_name].invoke(**kwargs)

--- a/jenkinsapi_tests/systests/test_jenkins.py
+++ b/jenkinsapi_tests/systests/test_jenkins.py
@@ -58,7 +58,15 @@ class JobTests(BaseSystemTest):
     def test_invoke_job(self):
         job_name = 'create_%s' % random_string()
         job = self.jenkins.create_job(job_name, EMPTY_JOB)
-        job.invoke()
+        job.invoke(block=True)
+        self.assertEquals(job.get_last_buildnumber(), 1)
+
+    def test_invoke_job_through_jobs(self):
+        job_name = 'create_%s' % random_string()
+        self.jenkins.create_job(job_name, EMPTY_JOB)
+        qi = self.jenkins.jobs.build(job_name=job_name, block=True)
+        self.assertEquals(self.jenkins[job_name].get_last_buildnumber(), 1)
+        self.assertIsInstance(qi, QueueItem)
 
     def test_invocation_object(self):
         job_name = 'create_%s' % random_string()

--- a/jenkinsapi_tests/unittests/test_jenkins.py
+++ b/jenkinsapi_tests/unittests/test_jenkins.py
@@ -8,7 +8,7 @@ except ImportError:
 from jenkinsapi.plugins import Plugins
 from jenkinsapi.utils.requester import Requester
 from jenkinsapi.jenkins import Jenkins, JenkinsBase, Job
-from jenkinsapi.custom_exceptions import JenkinsAPIException, UnknownJob, BadURL
+from jenkinsapi.custom_exceptions import JenkinsAPIException
 
 
 class TestJenkins(unittest.TestCase):
@@ -128,10 +128,10 @@ class TestJenkins(unittest.TestCase):
         _poll.return_value = {
             'jobs': [
                 {'name': 'job_one',
-                 'url': 'http://localhost:8080/job_one',
+                 'url': 'http://localhost:8080/job/job_one',
                  'color': 'blue'},
                 {'name': 'job_two',
-                 'url': 'http://localhost:8080/job_two',
+                 'url': 'http://localhost:8080/job/job_two',
                  'color': 'blue'},
             ]
         }
@@ -141,7 +141,7 @@ class TestJenkins(unittest.TestCase):
                     username='foouser', password='foopassword')
         job = J.create_job('job_one', None)
         self.assertTrue(isinstance(job, Job))
-        self.assertTrue(job.baseurl == 'http://localhost:8080/job_one')
+        self.assertTrue(job.baseurl == 'http://localhost:8080/job/job_one')
         self.assertTrue(job.name == 'job_one')
 
     # Here we're going to test function, which is going to modify
@@ -179,32 +179,6 @@ class TestJenkins(unittest.TestCase):
         }
     ]
 
-    # Mock function
-    def second_call_poll(tree=None):
-        return TestJenkins.create_job_returns.pop(0)
-
-    def job_second_call_poll(tree=None):
-        return {}
-
-    # Patch Jenkins with mock function
-    @mock.patch.object(Jenkins, '_poll', side_effect=second_call_poll)
-    @mock.patch.object(Job, '_poll', side_effect=job_second_call_poll)
-    def test_create_new_job(self, _poll, _job_poll):
-        _job_poll.return_value = {}
-
-        mock_requester = Requester(username='foouser', password='foopassword')
-        mock_requester.post_xml_and_confirm_status = mock.MagicMock(
-            return_value='')
-
-        J = Jenkins('http://localhost:8080/',
-                    username='foouser', password='foopassword',
-                    requester=mock_requester)
-
-        job = J.create_job('job_new', None)
-        self.assertTrue(isinstance(job, Job))
-        self.assertTrue(job.baseurl == 'http://localhost:8080/job_new')
-        self.assertTrue(job.name == 'job_new')
-
     @mock.patch.object(JenkinsBase, '_poll')
     @mock.patch.object(Jenkins, '_poll')
     @mock.patch.object(Job, '_poll')
@@ -233,7 +207,7 @@ class TestJenkins(unittest.TestCase):
         with self.assertRaises(JenkinsAPIException) as ar:
             J.create_job('job_new', None)
 
-        self.assertEquals(str(ar.exception), 'Cannot create job job_new')
+        self.assertEquals(str(ar.exception), 'Job XML config cannot be empty')
 
     @mock.patch.object(JenkinsBase, '_poll')
     @mock.patch.object(Jenkins, '_poll')
@@ -371,7 +345,8 @@ class TestJenkinsURLs(unittest.TestCase):
                     'dependencies': [{}, {}, {}, {}],
                     'longName': 'Jenkins Subversion Plug-in', 'active': True,
                     'shortName': 'subversion', 'backupVersion': None,
-                    'url': 'http://wiki.jenkins-ci.org/display/JENKINS/Subversion+Plugin',
+                    'url': 'http://wiki.jenkins-ci.org/'
+                    'display/JENKINS/Subversion+Plugin',
                     'enabled': True, 'pinned': False, 'version': '1.45',
                     'supportsDynamicLoad': 'MAYBE', 'bundled': True
                 }


### PR DESCRIPTION
This PR addresses #412 

With this change `Jobs` object is only going to access data via `iteritems()` method, which is used by other iterators in this object. Job removal and creation will not try to query Jenkins after job is deleted or created.

`Jobs.poll()` function will ask Jenkins for job name and status. Getting job url is done in `Job` object itself.

I also updated `Jobs.build()` function, so now it is closer to `Job.invoke()` and allows starting builds like this:

```
api = Jenkins('http://localhost:8080/')
api.jobs.build('my_job', block=True)
```
in addition to this:
```
api = Jenkins('http://localhost:8080/')
api['my_job'].invoke(block=True)
```
Some unit tests were removed in process because they were unnecessary complex and can be made easier as systests.