### PR TITLE
J2x insecure start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ install:
 script:
     - pep8 --ignore=E501 jenkinsapi/*.py
     - pylint --rcfile=pylintrc jenkinsapi/*.py --disable R0912
-    - nosetests jenkinsapi_tests
+    - nosetests -v jenkinsapi_tests

--- a/jenkinsapi/credentials.py
+++ b/jenkinsapi/credentials.py
@@ -91,8 +91,8 @@ class Credentials(JenkinsBase):
         if description not in self:
             params = credential.get_attributes()
             url = (
-                '%s/credential-store/domain/_/createCredentials'
-                % self.jenkins.baseurl
+                '%s/createCredentials'
+                % self.baseurl
             )
         else:
             raise JenkinsAPIException('Updating credentials is not supported '
@@ -121,8 +121,8 @@ class Credentials(JenkinsBase):
             'Submit': 'OK',
             'json': {}
         }
-        url = ('%s/credential-store/domain/_/credential/%s/doDelete'
-               % (self.jenkins.baseurl, self[description].credential_id))
+        url = ('%s/credential/%s/doDelete'
+               % (self.baseurl, self[description].credential_id))
         try:
             self.jenkins.requester.post_and_confirm_status(
                 url, params={}, data=urlencode(params)

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -389,7 +389,11 @@ class Jenkins(JenkinsBase):
         """
         Return credentials
         """
-        url = '%s/credential-store/domain/_/' % self.baseurl
+        if int(self.version[0:1]) == 1:
+            url = '%s/credential-store/domain/_/' % self.baseurl
+        else:
+            url = '%s/credentials/store/system/domain/_/' % self.baseurl
+
         return Credentials(url, self)
 
     @property

--- a/jenkinsapi_utils/jenkins_launcher.py
+++ b/jenkinsapi_utils/jenkins_launcher.py
@@ -149,7 +149,9 @@ class JenkinsLancher(object):
 
             os.chdir(self.war_directory)
 
-            jenkins_command = ['java', '-jar', self.war_filename,
+            jenkins_command = ['java',
+                               '-Djenkins.install.runSetupWizard=false',
+                               '-jar', self.war_filename,
                                '--httpPort=%d' % self.http_port]
 
             log.info("About to start Jenkins...")


### PR DESCRIPTION
Start Jenkins with `-Djenkins.install.runSetupWizard=false` parameter, which disables security and Setup wizard.

Fixes #448 - latest version of `credentials` plugin uses different url.

Made Travis test log verbose, so I don't have to wait till full test run to see which test is broken.