### PR TITLE
Adding a why property to a queueitem object

### DIFF
--- a/jenkinsapi/queue.py
+++ b/jenkinsapi/queue.py
@@ -99,6 +99,10 @@ class QueueItem(JenkinsBase):
     def name(self):
         return self._data['task']['name']
 
+    @property
+    def why(self):
+        return self._data.get('why')
+
     def get_jenkins_obj(self):
         return self.jenkins
 

--- a/jenkinsapi_tests/systests/test_queue.py
+++ b/jenkinsapi_tests/systests/test_queue.py
@@ -90,7 +90,7 @@ class TestQueue(BaseSystemTest):
 
         queue = self.jenkins.get_queue()
         for _, item in queue.iteritems():
-            self.assertIs(type(item.why()), str)
+            assert item.why() is StringType
 
         # Clean up after ourselves
         for _, item in queue.iteritems():

--- a/jenkinsapi_tests/systests/test_queue.py
+++ b/jenkinsapi_tests/systests/test_queue.py
@@ -79,6 +79,24 @@ class TestQueue(BaseSystemTest):
         time.sleep(1)
         self.assertFalse(j.is_queued_or_running())
 
+    def test_queueitem_for_why_field(self):
+        # Make some jobs just in case there aren't any.
+        job_names = [random_string() for _ in range(5)]
+        jobs = []
+        for job_name in job_names:
+            j = self.jenkins.create_job(job_name, LONG_RUNNING_JOB)
+            jobs.append(j)
+            j.invoke()
+
+        queue = self.jenkins.get_queue()
+
+        # TEST!
+        self.assertIsInstance(queue[0]['why'], str)
+        self.assertIn(queue[0], 'why')
+
+        # Clean up after ourselves
+        for _, item in queue.iteritems():
+            queue.delete_item(item)
 
 if __name__ == '__main__':
     logging.basicConfig()

--- a/jenkinsapi_tests/systests/test_queue.py
+++ b/jenkinsapi_tests/systests/test_queue.py
@@ -90,7 +90,7 @@ class TestQueue(BaseSystemTest):
 
         queue = self.jenkins.get_queue()
         for _, item in queue.iteritems():
-            self.assertIs(item.why(), str)
+            self.assertIs(type(item.why()), str)
 
         # Clean up after ourselves
         for _, item in queue.iteritems():

--- a/jenkinsapi_tests/systests/test_queue.py
+++ b/jenkinsapi_tests/systests/test_queue.py
@@ -90,7 +90,7 @@ class TestQueue(BaseSystemTest):
 
         queue = self.jenkins.get_queue()
         for _, item in queue.iteritems():
-          self.assertIsInstance(item.why(), str)
+            self.assertIs(item.why(), str)
 
         # Clean up after ourselves
         for _, item in queue.iteritems():

--- a/jenkinsapi_tests/systests/test_queue.py
+++ b/jenkinsapi_tests/systests/test_queue.py
@@ -81,7 +81,7 @@ class TestQueue(BaseSystemTest):
 
     def test_queueitem_for_why_field(self):
         # Make some jobs just in case there aren't any.
-        job_names = [random_string() for _ in range(5)]
+        job_names = [random_string() for _ in range(2)]
         jobs = []
         for job_name in job_names:
             j = self.jenkins.create_job(job_name, LONG_RUNNING_JOB)
@@ -89,10 +89,8 @@ class TestQueue(BaseSystemTest):
             j.invoke()
 
         queue = self.jenkins.get_queue()
-
-        # TEST!
-        self.assertIsInstance(queue[0]['why'], str)
-        self.assertIn(queue[0], 'why')
+        for _, item in queue.iteritems():
+          self.assertIsInstance(item.why(), str)
 
         # Clean up after ourselves
         for _, item in queue.iteritems():

--- a/jenkinsapi_tests/systests/test_queue.py
+++ b/jenkinsapi_tests/systests/test_queue.py
@@ -90,7 +90,7 @@ class TestQueue(BaseSystemTest):
 
         queue = self.jenkins.get_queue()
         for _, item in queue.iteritems():
-            assert item.why() is StringType
+            self.assertIsInstance(item.why, str)
 
         # Clean up after ourselves
         for _, item in queue.iteritems():


### PR DESCRIPTION
I'm currently using this library and noticed that it didn't have a way to read the "why" field of the QueueItem object without referring to _data directly.

This patch adds a property to make this cleaner. 

I didn't see any tests for this, so I haven't added any here. It's a pretty straightforward change. 